### PR TITLE
require node-fetch and filepath regex

### DIFF
--- a/clyp-downloader.cjs
+++ b/clyp-downloader.cjs
@@ -5,6 +5,7 @@
  * @author ari melody <ari@arimelody.me>
  */
 
+const fetch = require('node-fetch'); 
 const process = require("process");
 const fs = require("fs");
 
@@ -82,8 +83,8 @@ async function main() {
     for (let i = 0; i < totalCount; i++) {
         const upload = uploads.pop();
 
-        const filepath = `mp3/${upload.name.replace(/[<>:"\/\\|?*]/gi, '_')} (${upload.id}).mp3`;
-        console.log(`Downloading ${upload.id} "${upload.name}" (${i}/${totalCount})...`);
+        const filepath = `mp3/${upload.name.replace(/[<>:"\/\\|?*]/gi, '_')} (${upload.id.replace(/[<>:"\/\\|?*]/gi, '_')}).mp3`;
+        console.log(`Downloading ${upload.id.replace(/[<>:"\/\\|?*]/gi, '_')} "${upload.name.replace(/[<>:"\/\\|?*]/gi, '_')}" (${i}/${totalCount})...`);
 
         const res = await fetch(upload.url)
         const blob = await res.blob()


### PR DESCRIPTION
hi, this is @[kat.bsky.girlonthemoon.xyz](https://bsky.app/profile/kat.bsky.girlonthemoon.xyz/). i used this script to successfully download and backup my years old clyp uploads. for that, thank you!

i had to tweak it a bit for it to work on my end. i'm not a javascript dev at all (i don't even know it) but my tweaks got it working for me when the original script crashed immediately.

the notable changes are adding regex escapes to the upload variables, and removing the mp3/ sub-directory to download to, as that was resulting in a crash for the script. i didn't remove any other code relating to the mp3 directory in case this can be fixed.

sorry if this is a superfluous PR. it's my second one ever actually. but i hope this helps others who are looking to back up their clyp accounts with such short notice.